### PR TITLE
refactor: update the misleading proctoring verified message

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-frontend-lib-special-exams
+frontend-lib-special-exams-mitol
 =================================
 
 This is a react library responsible for extending learning app with special exams functionality, e.g. proctored/timed exams. 
@@ -8,7 +8,7 @@ Set up instructions
 
 1. Clone your new repo:
 
-  ``git clone https://github.com/edx/frontend-lib-special-exams.git``
+  ``git clone https://github.com/mitodl/frontend-lib-special-exams-mitol.git``
 
 2. Use node v12.x.
 
@@ -16,7 +16,31 @@ Set up instructions
 
 3. Install npm dependencies:
 
-  ``cd frontend-lib-special-exams && npm install``
+  ``cd frontend-lib-special-exams-mitol && npm install``
+
+
+Local Development
+-----------------
+
+For local development and testing follow these steps. (Learning MFE (``frontend-app-learning``) is the parent app of ``frontend-lib-special-exams-mitol``)
+
+* Clone ``frontend-lib-special-exams-mitol`` into ``frontend-app-learning directory``.
+* Change directory to the ``frontend-lib-special-exams-mitol`` and run the following commands:
+
+    npm i
+
+    npm build
+* Verify a ``dist/`` folder has been created.
+* Change directory back to ``frontend-app-learning`` and create a ``module.config.js`` file
+* Place the following code in the module.config.js::
+
+        module.exports = {
+          localModules: [
+            { moduleName: '@edx/frontend-lib-special-exams-mitol', dir: './packages/frontend-lib-special-exams-mitol', dist: 'src' },
+          ],
+        };
+* Restart ``frontend-app-learning`` e.g. (``docker-compose restart frontend-app-learning``) and verify that it is using the local version from @mitol/frontend-lib-special-exams
+* For css changes you might need to rebuild again.
 
 Build Process Notes
 -------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@edx/frontend-lib-special-exams",
+  "name": "@mitodl/frontend-lib-special-exams-mitol",
   "version": "1.14.0",
-  "description": "Special exams lib",
+  "description": "Special exams lib for MIT applications",
   "main": "dist/index.js",
   "release": {
     "branches": [
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/edx/frontend-lib-special-exams.git"
+    "url": "git+https://github.com/mitodl/frontend-lib-special-exams-mitol.git"
   },
   "publishConfig": {
     "access": "public"
@@ -38,9 +38,9 @@
     }
   },
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/edx/frontend-lib-special-exams",
+  "homepage": "https://github.com/mitodl/frontend-lib-special-exams-mitol",
   "bugs": {
-    "url": "https://github.com/edx/frontend-lib-special-exams/issues"
+    "url": "https://github.com/mitodl/frontend-lib-special-exams-mitol/issues"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
+++ b/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
@@ -183,7 +183,7 @@ describe('SequenceExamWrapper', () => {
       </ExamStateProvider>,
       { store },
     );
-    expect(getByTestId('proctored-exam-instructions-title')).toHaveTextContent('Exams are being reviewed and a final grade will be available soon.');
+    expect(getByTestId('proctored-exam-instructions-title')).toHaveTextContent('Your exam was submitted successfully.');
   });
 
   it('Instructions are shown when attempt status is rejected', () => {

--- a/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
+++ b/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
@@ -183,7 +183,7 @@ describe('SequenceExamWrapper', () => {
       </ExamStateProvider>,
       { store },
     );
-    expect(getByTestId('proctored-exam-instructions-title')).toHaveTextContent('Your proctoring session was reviewed successfully.');
+    expect(getByTestId('proctored-exam-instructions-title')).toHaveTextContent('Exams are being reviewed and a final grade will be available soon.');
   });
 
   it('Instructions are shown when attempt status is rejected', () => {

--- a/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
@@ -6,8 +6,7 @@ const VerifiedProctoredExamInstructions = () => (
     <h3 className="h3" data-testid="proctored-exam-instructions-title">
       <FormattedMessage
         id="exam.VerifiedProctoredExamInstructions.title"
-        defaultMessage={'Your proctoring session was reviewed successfully. '
-        + 'Go to your progress page to view your exam grade.'}
+        defaultMessage={'Exams are being reviewed and a final grade will be available soon.'}
       />
     </h3>
   </div>

--- a/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
@@ -6,7 +6,8 @@ const VerifiedProctoredExamInstructions = () => (
     <h3 className="h3" data-testid="proctored-exam-instructions-title">
       <FormattedMessage
         id="exam.VerifiedProctoredExamInstructions.title"
-        defaultMessage={'Exams are being reviewed and a final grade will be available soon.'}
+        defaultMessage={'Your exam was submitted successfully. Exams are being '
+        + 'reviewed and a final grade will be available soon.'}
       />
     </h3>
   </div>


### PR DESCRIPTION
##  Ticket:
https://github.com/mitodl/mitxonline/issues/374

## What's this PR do?
- Updates a message that can be a bit misleading when the proctored exams have been reviewed and the grades haven't been published yet.
- The message is changed from `Your proctoring session was reviewed successfully. Go to your progress page to view your exam grade.` to `Exams are being reviewed and a final grade will be available soon.`
- Updates the configurations for the npm 


## Testing Instructions:
- Create a proctored exam through the studio and take it to a verified state. (You can follow the instructions [here](https://github.com/mitodl/mitxonline/issues/374#issuecomment-1055146296))
- Check out this branch inside your devstack `/frontend-app-learning/packages` (If packages dir doesn't exist you can create one, that's easy to test it around)
- Create a file named `module.config.js` inside your `/frontend-app-learning` directory and add the following:
```
module.exports = {
  localModules: [
    { moduleName: '@edx/frontend-lib-special-exams', dir: './packages/frontend-lib-special-exams', dist: 'src' },
  ],
};
```
- In your terminal restart that `frontend-app-learning` container e.g. `docker-compose restart frontend-app-learning`
## Documentation/Discussion:
A relevant discussion can be seen on [this ticket](https://github.com/mitodl/mitxonline/issues/374)

## Screenshot:
**New**
<img width="1654" alt="Screenshot 2022-03-16 at 6 14 05 PM" src="https://user-images.githubusercontent.com/34372316/158597902-2e7e1d01-d8a2-4147-9353-e7f63dc514d4.png">

**Old**
<img width="951" alt="proctored_reviewed_old" src="https://user-images.githubusercontent.com/34372316/158599883-01e97aed-e777-47b0-9fee-e9472cac087e.png">
